### PR TITLE
- Fix for BVM-898

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -1000,7 +1000,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
 
     @Override
-    public void onHostPause() { }
+    public void onHostPause() {
+      if (getSettings().getJavaScriptEnabled()) {
+        evaluateJavascriptWithFallback("(function(){document.getElementsByTagName('video')[0].pause();})()");
+      }
+    }
 
     @Override
     public void onHostDestroy() { }


### PR DESCRIPTION
Pausing the video in Android when application is going to the background. This prevents the video from auto playing when coming back to the foreground